### PR TITLE
Fix customer validation method with typo in method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Class | Method | HTTP request | Description
 *Customer* | [**list**](docs/Customer.md#list) | **GET** /customer | List Customers
 *Customer* | [**risk_action**](docs/Customer.md#risk_action) | **POST** /customer/set_risk_action | White/blacklist Customer
 *Customer* | [**update**](docs/Customer.md#update) | **PUT** /customer/{code} | Update Customer
-*Customer* | [**validatte**](docs/Customer.md#validatte) | **POST** /customer/{code}/identification | Validate Customer
+*Customer* | [**validate**](docs/Customer.md#validate) | **POST** /customer/{code}/identification | Validate Customer
 *DedicatedVirtualAccount* | [**add_split**](docs/DedicatedVirtualAccount.md#add_split) | **POST** /dedicated_account/split | Split Dedicated Account Transaction
 *DedicatedVirtualAccount* | [**available_providers**](docs/DedicatedVirtualAccount.md#available_providers) | **GET** /dedicated_account/available_providers | Fetch Bank Providers
 *DedicatedVirtualAccount* | [**create**](docs/DedicatedVirtualAccount.md#create) | **POST** /dedicated_account | Create Dedicated Account

--- a/docs/Customer.md
+++ b/docs/Customer.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 [**list**](Customer.md#list) | **GET** /customer | List Customers
 [**risk_action**](Customer.md#risk_action) | **POST** /customer/set_risk_action | White/blacklist Customer
 [**update**](Customer.md#update) | **PUT** /customer/{code} | Update Customer
-[**validatte**](Customer.md#validatte) | **POST** /customer/{code}/identification | Validate Customer
+[**validate**](Customer.md#validate) | **POST** /customer/{code}/identification | Validate Customer
 
 
 # **create**
@@ -353,8 +353,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **validatte**
-> Accepted validatte(code, first_name, last_name, type, country, bvn, bank_code, account_number, value=value)
+# **validate**
+> Accepted validate(code, first_name, last_name, type, country, bvn, bank_code, account_number, value=value)
 
 Validate Customer
 
@@ -381,7 +381,7 @@ account_number = 'account_number_example' # str | Customer's bank account number
 
 # Validate Customer
 
-response = paystack.Customer.validatte(
+response = paystack.Customer.validate(
     code,
     first_name,
     last_name,

--- a/paystack/__init__.py
+++ b/paystack/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 api_key=None
 
 # import apis into sdk package

--- a/paystack/api/customer_.py
+++ b/paystack/api/customer_.py
@@ -458,7 +458,7 @@ class Customer(object):
 
 
     @classmethod
-    def validatte(cls, code, first_name, last_name, type, country, bvn, bank_code, account_number, **kwargs):  # noqa: E501
+    def validate(cls, code, first_name, last_name, type, country, bvn, bank_code, account_number, **kwargs):  # noqa: E501
         """Validate Customer  # noqa: E501
 
         Validate a customer's identity  # noqa: E501
@@ -504,42 +504,42 @@ class Customer(object):
             if key not in all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method validatte" % key
+                    " to method validate" % key
                 )
             local_var_params[key] = val
         del local_var_params['kwargs']
         # verify the required parameter 'code' is set
         if cls().api_client.client_side_validation and ('code' not in local_var_params or  # noqa: E501
                                                         local_var_params['code'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `code` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `code` when calling `validate`")  # noqa: E501
         # verify the required parameter 'first_name' is set
         if cls().api_client.client_side_validation and ('first_name' not in local_var_params or  # noqa: E501
                                                         local_var_params['first_name'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `first_name` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `first_name` when calling `validate`")  # noqa: E501
         # verify the required parameter 'last_name' is set
         if cls().api_client.client_side_validation and ('last_name' not in local_var_params or  # noqa: E501
                                                         local_var_params['last_name'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `last_name` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `last_name` when calling `validate`")  # noqa: E501
         # verify the required parameter 'type' is set
         if cls().api_client.client_side_validation and ('type' not in local_var_params or  # noqa: E501
                                                         local_var_params['type'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `type` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `type` when calling `validate`")  # noqa: E501
         # verify the required parameter 'country' is set
         if cls().api_client.client_side_validation and ('country' not in local_var_params or  # noqa: E501
                                                         local_var_params['country'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `country` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `country` when calling `validate`")  # noqa: E501
         # verify the required parameter 'bvn' is set
         if cls().api_client.client_side_validation and ('bvn' not in local_var_params or  # noqa: E501
                                                         local_var_params['bvn'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `bvn` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `bvn` when calling `validate`")  # noqa: E501
         # verify the required parameter 'bank_code' is set
         if cls().api_client.client_side_validation and ('bank_code' not in local_var_params or  # noqa: E501
                                                         local_var_params['bank_code'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `bank_code` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `bank_code` when calling `validate`")  # noqa: E501
         # verify the required parameter 'account_number' is set
         if cls().api_client.client_side_validation and ('account_number' not in local_var_params or  # noqa: E501
                                                         local_var_params['account_number'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `account_number` when calling `validatte`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `account_number` when calling `validate`")  # noqa: E501
 
 
         path_params = {}

--- a/paystack/api_client.py
+++ b/paystack/api_client.py
@@ -71,7 +71,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'paystack-python/1.0.0'
+        self.user_agent = 'paystack-python/1.0.1'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/paystack/configuration.py
+++ b/paystack/configuration.py
@@ -318,7 +318,7 @@ ssl_ca_cert=None,
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0.0\n"\
-               "SDK Package Version: 1.0.0".\
+               "SDK Package Version: 1.0.1".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "paystack-sdk"
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## What issue does this change solve?
The customer. validation method was spelled wrongly as `validatte`, this patch is to update the method name to `validate`.


# Additional context
None